### PR TITLE
Update Duktape to 0.8.1

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -6,5 +6,5 @@ shards:
 
   duktape:
     github: jessedoyle/duktape.cr
-    version: 0.8.0
+    version: 0.8.1
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: coffee-script
-version: 0.1.2
+version: 0.1.3
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>


### PR DESCRIPTION
- Update Duktape.cr dependency from 0.8.0 to 0.8.1 for
  Crystal 0.14.2 compatibility.
