### PR TITLE
fix(#11): Update for Crystal 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        crystal: [latest, nightly]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Crystal
+        uses: oprypin/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal }}
+      - name: Download source
+        uses: actions/checkout@v2
+      - name: Dependencies
+        run: shards install
+      - name: Run specs
+        run: crystal spec
+      - name: Check formatting
+        run: crystal tool format --check src spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: crystal
-sudo: false
-email: false

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add this to your project's `shard.yml`:
 dependencies:
   coffee-script:
     github: jessedoyle/coffee-script
-    version: ~> 0.6.0
+    version: ~> 1.0
 ```
 
 then execute `shards install`.
@@ -44,7 +44,7 @@ CoffeeScript.compile(src, { bare: true }) # => compiled code
 
 ## Dependencies
 
-This library depends on the [coffee-script-source](https://github.com/jessedoyle/coffee-script-source) shard which will be updated anytime a new version of CoffeeScript is released. The `coffee-script-source` shard's version number will match the corresponding CoffeeScript compiler.
+This library depends on the [coffee-script-source](https://github.com/jessedoyle/coffee-script-source) shard, please see the [releases page](https://github.com/jessedoyle/coffee-script-source/releases) for compiler versions.
 
 This library uses [duktape.cr](https://github.com/jessedoyle/duktape.cr) as the javascript runtime.
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,15 +1,17 @@
 name: coffee-script
-version: 0.6.0
+version: 1.0.0
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>
 
+crystal: '>= 0.35.1'
+
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.13
+    version: '>= 1.0, < 3.0'
   coffee-script-source:
     github: jessedoyle/coffee-script-source
-    version: ~> 1.12.6
+    version: ~> 2.0
 
 license: MIT

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,5 +1,2 @@
 require "spec"
 require "../src/coffee-script"
-
-# Disable logging
-Duktape.logger.level = Logger::Severity::UNKNOWN


### PR DESCRIPTION
* Resolves https://github.com/jessedoyle/coffee-script/issues/11.
* **breaking change** - Require Crystal >= 0.35.1 for compatability
  with Crystal/Shards 1.0.
* Point to the 2.X release of coffee-script-source (this includes
  the 1.12.8 release of the coffeescript compiler) for Crystal 1.0
  compatability.
* Lock `duktape` to `>= 1.0 and < 3.0` to be compatible with both
  the current 1.X release family as well as a future 2.X release.
* Move from Travis CI to GitHub Actions for CI.